### PR TITLE
fix lsp stdio error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,6 @@ function createLanguageClient(): LanguageClient {
   let serverOptions: ServerOptions = {
     command: "gleam",
     args: ["lsp"],
-    transport: TransportKind.stdio,
     options: {
       env: Object.assign(process.env, {
         GLEAM_LOG: "info",


### PR DESCRIPTION
Currently, the `transport` field makes gleam lsp failed to start and report error: `Found argument '--stdio' which wasn't expected, or isn't valid in this context`, disabling it will prevent this situation.