### PR TITLE
Fix scientific notation syntax highlighting

### DIFF
--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -125,7 +125,7 @@
     },
     "decimal_number": {
       "name": "constant.numeric.decimal.gleam",
-      "match": "\\b[[:digit:]]+(_?[[:digit:]])*(\\.[[:digit:]]*)?(e-?[[:digit:]])?\\b",
+      "match": "\\b[[:digit:]]+(_?[[:digit:]])*(\\.[[:digit:]]*)?(e-?[[:digit:]]*)?\\b",
       "patterns": []
     },
     "hexadecimal_number": {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -125,7 +125,7 @@
     },
     "decimal_number": {
       "name": "constant.numeric.decimal.gleam",
-      "match": "\\b[[:digit:]][[:digit:]_]*(\\.[[:digit:]]*)?\\b",
+      "match": "\\b[[:digit:]]+(\\.[[:digit:]]*)?(e-?[[:digit:]])?\\b",
       "patterns": []
     },
     "hexadecimal_number": {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -125,7 +125,7 @@
     },
     "decimal_number": {
       "name": "constant.numeric.decimal.gleam",
-      "match": "\\b[[:digit:]]+(\\.[[:digit:]]*)?(e-?[[:digit:]])?\\b",
+      "match": "\\b[[:digit:]]+(_?[[:digit:]])*(\\.[[:digit:]]*)?(e-?[[:digit:]])?\\b",
       "patterns": []
     },
     "hexadecimal_number": {


### PR DESCRIPTION
Fixes #59
Before:
![image](https://github.com/gleam-lang/vscode-gleam/assets/11275573/b5de58bf-0225-40f7-964f-34abfd41cb99)

After:
![image](https://github.com/gleam-lang/vscode-gleam/assets/11275573/bca7625d-b61f-45b7-b31b-6bdf1f9e11ab)
