### PR TITLE
Change Github link from the lang repo to the extension repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ provides formatting, goto-definition, autocompletion, and more!
 
 Run `npm run compile-watch` in a terminal and hit F5 in vscode.
 
-Contribute to the extension on [Github](https://github.com/gleam-lang/gleam)
+Contribute to the extension on [Github](https://github.com/gleam-lang/vscode-gleam)


### PR DESCRIPTION
The Github link in the readme currently links to the Gleam language repo. This should be changed to the repo for the VS Code extension to avoid confusion.