### PR TITLE
Add highlighting to Markdown fenced code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
         "language": "gleam",
         "scopeName": "source.gleam",
         "path": "./syntaxes/gleam.tmLanguage.json"
+      },
+      {
+        "scopeName": "markdown.gleam.codeblock",
+        "path": "./syntaxes/gleam.codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.gleam": "gleam"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/gleam.codeblock.json
+++ b/syntaxes/gleam.codeblock.json
@@ -1,0 +1,48 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#gleam-code-block"
+    }
+  ],
+  "repository": {
+    "gleam-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(gleam)((\\s+|:|,|\\{|\\?)[^`]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language"
+        },
+        "7": {
+          "name": "punctuation.definition.markdown"
+        },
+        "8": {
+          "name": "fenced_code.block.language.attributes"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.gleam",
+          "patterns": [
+            {
+              "include": "source.gleam"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.gleam.codeblock"
+}


### PR DESCRIPTION
Adds support for syntax highlighting in Markdown fenced code blocks by adding an [injection grammar](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#injection-grammars). I used [julia-vscode](https://github.com/julia-vscode/julia-vscode/blob/main/package.json) as an example.

**Before:**

<img width="212" alt="without-syntax-highlighting" src="https://github.com/gleam-lang/vscode-gleam/assets/19388254/11b0dc5c-d9e2-480d-9bfe-bdb1471c38a2">

**After:**

<img width="212" alt="with-syntax-highlighting" src="https://github.com/gleam-lang/vscode-gleam/assets/19388254/da4b4575-7fd0-4485-a5a5-e3b9ae537f6d">

Fixes #76