### PR TITLE
Fix highlighting for non-decimal numbers with underscores

### DIFF
--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -115,12 +115,12 @@
     },
     "binary_number": {
       "name": "constant.numeric.binary.gleam",
-      "match": "\\b0b[0-1]+\\b",
+      "match": "\\b0b(_?[01])+\\b",
       "patterns": []
     },
     "octal_number": {
       "name": "constant.numeric.octal.gleam",
-      "match": "\\b0o[0-7]+\\b",
+      "match": "\\b0o(_?[0-7])+\\b",
       "patterns": []
     },
     "decimal_number": {
@@ -130,7 +130,7 @@
     },
     "hexadecimal_number": {
       "name": "constant.numeric.hexadecimal.gleam",
-      "match": "\\b0x[[:xdigit:]]+\\b",
+      "match": "\\b0x(_?[[:xdigit:]])+\\b",
       "patterns": []
     },
     "boolean": {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -115,12 +115,12 @@
     },
     "binary_number": {
       "name": "constant.numeric.binary.gleam",
-      "match": "\\b0b(_?[01])+\\b",
+      "match": "\\b0[bB](_?[01])+\\b",
       "patterns": []
     },
     "octal_number": {
       "name": "constant.numeric.octal.gleam",
-      "match": "\\b0o(_?[0-7])+\\b",
+      "match": "\\b0[oO](_?[0-7])+\\b",
       "patterns": []
     },
     "decimal_number": {
@@ -130,7 +130,7 @@
     },
     "hexadecimal_number": {
       "name": "constant.numeric.hexadecimal.gleam",
-      "match": "\\b0x(_?[[:xdigit:]])+\\b",
+      "match": "\\b0[xX](_?[[:xdigit:]])+\\b",
       "patterns": []
     },
     "boolean": {


### PR DESCRIPTION
Resolves #71

Made some minor changes to the match regexes for binary, octal, and hexadecimal numbers. The syntax highlighting should now be indicative of valid Gleam number formats:

- A single underscore in the middle of a number (including between the base prefix and first digit) ✅ 
- More than one contiguous underscore ❌ 
- An underscore at the start or end of a number ❌ 

### Before

![image](https://github.com/gleam-lang/vscode-gleam/assets/130914459/16652f96-c1db-44df-bd07-e81a3e613a37)

### After
![image](https://github.com/gleam-lang/vscode-gleam/assets/130914459/4892a30a-af56-4e7e-8d52-4f9256424140)
