### PR TITLE
Highlight discards as comments

### DIFF
--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -16,6 +16,9 @@
     },
     {
       "include": "#entity"
+    },
+    {
+      "include": "#discards"
     }
   ],
   "repository": {
@@ -163,6 +166,10 @@
           "match": "\\b([[:lower:]][[:word:]]*):"
         }
       ]
+    },
+    "discards": {
+      "name": "comment.unused.gleam",
+      "match": "\\b_(?:[[:word:]]+)?\\b"
     }
   },
   "scopeName": "source.gleam"


### PR DESCRIPTION
Resolves #24

As #30 seems to be stale, I thought it would be worth raising a small PR focused solely on closing #24, as it's a feature I'd quite like as I learn Gleam.

The PR adds a `#discards` pattern to the syntax that matches any word starting with an underscore, or isolated underscore(s). From brief investigation, `comment.unused.gleam` seems to be the most idiomatic/consistent scope for this pattern. As mentioned in gleam-lang/gleam.vim#6, Elixir highlights discards as comments, and [vscode-elixir-ls](https://github.com/elixir-lsp/vscode-elixir-ls) uses a similar `comment.unused.elixir` scope. This tends to work pretty well with any theme that doesn't use outlandish comment colouring.

Below is an example of the changes with as many edge cases as I could think of (with limited knowledge of the language) - the non-decimal number highlighting will be fixed with my other PR (#78). I noticed that gleam-lang/gleam.vim#7 was having some trouble with generic arguments, so I've included an example of that working. Perhaps someone could try translating my regex for use with the Vim plugin if the functionality is still desired.

![image](https://github.com/gleam-lang/vscode-gleam/assets/130914459/cefce73b-25a8-4c82-bfa8-8759e29b9507)