### PR TITLE
Update to match last version of gleam

### DIFF
--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -135,7 +135,7 @@
     },
     "decimal_number": {
       "name": "constant.numeric.decimal.gleam",
-      "match": "\\b[[:digit:]](_?[[:digit:]])*(\\.(e-?[[:digit:]]|[[:digit:]]?)(_?[[:digit:]])*)?\\b",
+      "match": "\\b[[:digit:]](_?[[:digit:]])*(\\.([[:digit:]](_?[[:digit:]])*)?(e-?[[:digit:]]|[[:digit:]]?)(_?[[:digit:]])*)?\\b",
       "patterns": []
     },
     "hexadecimal_number": {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -125,12 +125,12 @@
     },
     "binary_number": {
       "name": "constant.numeric.binary.gleam",
-      "match": "\\b0[bB][01]+\\b",
+      "match": "\\b0[bB]0*1[01_]*\\b",
       "patterns": []
     },
     "octal_number": {
       "name": "constant.numeric.octal.gleam",
-      "match": "\\b0[oO][0-7]+\\b",
+      "match": "\\b0[oO]0*[1-7][0-7]*\\b",
       "patterns": []
     },
     "decimal_number": {
@@ -140,7 +140,7 @@
     },
     "hexadecimal_number": {
       "name": "constant.numeric.hexadecimal.gleam",
-      "match": "\\b0[xX][[:xdigit:]]+\\b",
+      "match": "\\b0[xX]0*[1-9a-zA-Z][0-9a-zA-Z]*\\b",
       "patterns": []
     },
     "boolean": {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -143,11 +143,6 @@
       "match": "\\b0[xX][[:xdigit:]]+\\b",
       "patterns": []
     },
-    "nil": {
-      "name": "constant.language.null.gleam",
-      "match": "\\bNil\\b",
-      "patterns": []
-    },
     "boolean": {
       "name": "constant.language.boolean.gleam",
       "match": "\\b(True|False)\\b",

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -112,9 +112,6 @@
           "include": "#decimal_number"
         },
         {
-          "include": "#nil"
-        },
-        {
           "include": "#boolean"
         },
         {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -26,7 +26,7 @@
       "patterns": [
         {
           "name": "keyword.control.gleam",
-          "match": "\\b(as|use|case|if|fn|import|let|assert|pub|type|opaque|const|todo|panic)\\b"
+          "match": "\\b(import|pub|panic|use|type|let|as|if|else|todo|const|case|assert|try|opaque|fn)\\b"
         },
         {
           "name": "keyword.operator.arrow.gleam",
@@ -41,12 +41,16 @@
           "match": "\\.\\."
         },
         {
+          "name": "keyword.operator.comparison.gleam",
+          "match": "(==|!=)"
+        },
+        {
           "name": "keyword.operator.comparison.float.gleam",
-          "match": "(<=\\.|>=\\.|==\\.|!=\\.|<\\.|>\\.)"
+          "match": "(<=\\.|>=\\.|<\\.|>\\.)"
         },
         {
           "name": "keyword.operator.comparison.int.gleam",
-          "match": "(<=|>=|==|!=|<|>)"
+          "match": "(<=|>=|<|>)"
         },
         {
           "name": "keyword.operator.logical.gleam",
@@ -62,7 +66,7 @@
         },
         {
           "name": "keyword.operator.arithmetic.float.gleam",
-          "match": "(\\+\\.|\\-\\.|/\\.|\\*\\.|%\\.)"
+          "match": "(\\+\\.|\\-\\.|/\\.|\\*\\.)"
         },
         {
           "name": "keyword.operator.arithmetic.int.gleam",
@@ -108,32 +112,40 @@
           "include": "#decimal_number"
         },
         {
+          "include": "#nil"
+        },
+        {
           "include": "#boolean"
         },
         {
           "name": "entity.name.type.gleam",
-          "match": "[[:upper:]][[:word:]]*"
+          "match": "[[:upper:]][[:alnum:]]*"
         }
       ]
     },
     "binary_number": {
       "name": "constant.numeric.binary.gleam",
-      "match": "\\b0[bB](_?[01])+\\b",
+      "match": "\\b0[bB][01]+\\b",
       "patterns": []
     },
     "octal_number": {
       "name": "constant.numeric.octal.gleam",
-      "match": "\\b0[oO](_?[0-7])+\\b",
+      "match": "\\b0[oO][0-7]+\\b",
       "patterns": []
     },
     "decimal_number": {
       "name": "constant.numeric.decimal.gleam",
-      "match": "\\b[[:digit:]]+(_?[[:digit:]])*(\\.[[:digit:]]*)?(e-?[[:digit:]]*)?\\b",
+      "match": "\\b[[:digit:]](_?[[:digit:]])*(\\.(e-?[[:digit:]]|[[:digit:]]?)(_?[[:digit:]])*)?\\b",
       "patterns": []
     },
     "hexadecimal_number": {
       "name": "constant.numeric.hexadecimal.gleam",
-      "match": "\\b0[xX](_?[[:xdigit:]])+\\b",
+      "match": "\\b0[xX][[:xdigit:]]+\\b",
+      "patterns": []
+    },
+    "nil": {
+      "name": "constant.language.null.gleam",
+      "match": "\\bNil\\b",
       "patterns": []
     },
     "boolean": {
@@ -144,7 +156,7 @@
     "entity": {
       "patterns": [
         {
-          "begin": "\\b([[:lower:]][[:word:]]*)([[:space:]]*)?\\(",
+          "begin": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*\\(",
           "end": "\\)",
           "patterns": [
             {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -26,7 +26,7 @@
       "patterns": [
         {
           "name": "keyword.control.gleam",
-          "match": "\\b(import|pub|panic|use|type|let|as|if|else|todo|const|case|assert|try|opaque|fn)\\b"
+          "match": "\\b(as|use|case|if|fn|import|let|assert|pub|type|opaque|const|todo|panic|else|try)\\b"
         },
         {
           "name": "keyword.operator.arrow.gleam",

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -143,11 +143,6 @@
       "match": "\\b0[xX]0*[1-9a-zA-Z][0-9a-zA-Z]*\\b",
       "patterns": []
     },
-    "boolean": {
-      "name": "constant.language.boolean.gleam",
-      "match": "\\b(True|False)\\b",
-      "patterns": []
-    },
     "entity": {
       "patterns": [
         {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -135,7 +135,7 @@
     },
     "decimal_number": {
       "name": "constant.numeric.decimal.gleam",
-      "match": "\\b[[:digit:]](_?[[:digit:]])*(\\.([[:digit:]](_?[[:digit:]])*)?(e-?[[:digit:]]|[[:digit:]]?)(_?[[:digit:]])*)?\\b",
+      "match": "\\b(0*[1-9][0-9_]*|0)(\\.(0*[1-9][0-9_]*|0)?(e-?0*[1-9][0-9]*)?)?\\b",
       "patterns": []
     },
     "hexadecimal_number": {


### PR DESCRIPTION
I just created another pull request to fix [gleam.vim](https://github.com/gleam-lang/gleam.vim/pull/14) issues too. Since I was at it, I thought I would fix issues here too.
Sadly, I couldn't test my changes yet, let me know if something seems off :)

Fixes :
- Equality operators are the same for all types
- Modulo operator does not make sens for floats
- Fixing multiple outdated regexes
- Missing 'Nil' highlight