### PR TITLE
Highlight `echo` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `echo` added as a keyword.
+
 ## v2.10.0 - 2024-08-15
 
 - Syntax highlighting has been improved.

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -26,7 +26,7 @@
       "patterns": [
         {
           "name": "keyword.control.gleam",
-          "match": "\\b(as|use|case|if|fn|import|let|assert|pub|type|opaque|const|todo|panic|else|try)\\b"
+          "match": "\\b(as|use|case|if|fn|import|let|assert|pub|type|opaque|const|todo|panic|else|try|echo)\\b"
         },
         {
           "name": "keyword.operator.arrow.gleam",


### PR DESCRIPTION
This PR adds support for highlighting the `echo` keyword which is releasing in Gleam 1.9.