### PR TITLE
Add missing keys to grammar

### DIFF
--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -112,18 +112,10 @@
           "include": "#decimal_number"
         },
         {
-          "include": "#boolean"
-        },
-        {
           "name": "entity.name.type.gleam",
           "match": "[[:upper:]][[:alnum:]]*"
         }
       ]
-    },
-    "boolean": {
-        "name": "constant.language.boolean.gleam",
-        "match": "\\bTrue|False\\b",
-        "patterns": []
     },
     "binary_number": {
       "name": "constant.numeric.binary.gleam",

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -120,6 +120,11 @@
         }
       ]
     },
+    "boolean": {
+        "name": "constant.language.boolean.gleam",
+        "match": "\\bTrue|False\\b",
+        "patterns": []
+    },
     "binary_number": {
       "name": "constant.numeric.binary.gleam",
       "match": "\\b0[bB]0*1[01_]*\\b",
@@ -171,5 +176,6 @@
       "match": "\\b_(?:[[:word:]]+)?\\b"
     }
   },
-  "scopeName": "source.gleam"
+  "scopeName": "source.gleam",
+  "fileTypes": ["gleam"]
 }


### PR DESCRIPTION
- "boolean" was missing which throws of strict grammar parsers
- "fileTypes" was missing which throws of some tools that depend on it for language detection