### PR TITLE
Add compiler installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@
 Provides syntax highlighting and use of the Gleam Language Server, which itself
 provides formatting, goto-definition, autocompletion, and more!
 
+This extension requires the Gleam compiler to be installed. If you don't already
+have the Gleam compiler on your system, please follow the instructions at
+<https://gleam.run/getting-started/installing/> before installing this
+extension.
+
 ## Hacking on the extension
 
 Run `npm run compile-watch` in a terminal and hit F5 in vscode.
 
-Contribute to the extension on [Github](https://github.com/gleam-lang/vscode-gleam)
+Contribute to the extension on [GitHub](https://github.com/gleam-lang/vscode-gleam)


### PR DESCRIPTION
We had someone come into Discord confused about why Gleam wasn't working after they had installed the extension. This should hopefully guide people in the right direction!

Also fixed a typographical annoyance 😛 