### PR TITLE
add capturing for: braces, brackets, comma, dot

### DIFF
--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -116,7 +116,7 @@
         },
         { 
             "name": "punctuation.accessor.dot.gleam",
-            "match": "(?<=[[:word:]])\\.(?=[[:word:]])"
+            "match": "\\."
         }
       ]
     },

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -19,6 +19,9 @@
     },
     {
       "include": "#discards"
+    },
+    {
+      "include": "#punctuation"
     }
   ],
   "repository": {
@@ -86,6 +89,34 @@
         {
           "name": "constant.character.escape.gleam",
           "match": "\\\\."
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        { 
+            "name": "punctuation.braces.begin.gleam",
+            "match": "\\{"
+        },
+        { 
+            "name": "punctuation.braces.end.gleam",
+            "match": "\\}"
+        },
+        { 
+            "name": "punctuation.brackets.begin.gleam",
+            "match": "\\["
+        },
+        { 
+            "name": "punctuation.brackets.end.gleam",
+            "match": "\\]"
+        },
+        { 
+            "name": "punctuation.separator.comma.gleam",
+            "match": ","
+        },
+        { 
+            "name": "punctuation.accessor.dot.gleam",
+            "match": "(?<=[[:word:]])\\.(?=[[:word:]])"
         }
       ]
     },

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -125,6 +125,10 @@
         { 
             "name": "punctuation.accessor.dot.gleam",
             "match": "\\."
+        },
+        { 
+            "name": "punctuation.colon.gleam",
+            "match": "\\:"
         }
       ]
     },

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -179,14 +179,12 @@
     "entity": {
       "patterns": [
         {
-        "begin": "(?:#)?([[:lower:]][[:word:]]*(?:\\.[[:lower:]][[:word:]]*)*)\\(",
+        "begin": "([[:lower:]][[:word:]]*)(\\()",
         "end": "\\)",
-        "patterns": [
-          { "include": "$self" }
-        ],
+        "patterns": [{ "include": "$self" }],
         "beginCaptures": {
           "1": { "name": "entity.name.function.gleam" },
-          "0": { "name": "punctuation.parens.begin.gleam" }
+          "2": { "name": "punctuation.parens.begin.gleam" }
         },
         "endCaptures": {
           "0": { "name": "punctuation.parens.end.gleam" }

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -112,7 +112,7 @@
         },
         { 
             "name": "punctuation.parens.begin.gleam",
-            "match": "#?\\("
+            "match": "#?[[:space:]]*\\("
         },
          { 
             "name": "punctuation.parens.end.gleam",
@@ -179,7 +179,7 @@
     "entity": {
       "patterns": [
         {
-        "begin": "([[:lower:]][[:word:]]*)(\\()",
+        "begin": "([[:lower:]][[:word:]]*)[[:space:]]*(\\()",
         "end": "\\)",
         "patterns": [{ "include": "$self" }],
         "beginCaptures": {

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -48,6 +48,10 @@
           "match": "(==|!=)"
         },
         {
+          "name": "keyword.operator.string.gleam",
+          "match": "<>"
+        },
+        {
           "name": "keyword.operator.comparison.float.gleam",
           "match": "(<=\\.|>=\\.|<\\.|>\\.)"
         },
@@ -58,10 +62,6 @@
         {
           "name": "keyword.operator.logical.gleam",
           "match": "(&&|\\|\\|)"
-        },
-        {
-          "name": "keyword.operator.string.gleam",
-          "match": "<>"
         },
         {
           "name": "keyword.operator.other.gleam",

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -111,6 +111,14 @@
             "match": "\\]"
         },
         { 
+            "name": "punctuation.parens.begin.gleam",
+            "match": "#?\\("
+        },
+         { 
+            "name": "punctuation.parens.end.gleam",
+            "match": "\\)"
+        },
+        { 
             "name": "punctuation.separator.comma.gleam",
             "match": ","
         },
@@ -171,18 +179,18 @@
     "entity": {
       "patterns": [
         {
-          "begin": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*\\(",
-          "end": "\\)",
-          "patterns": [
-            {
-              "include": "$self"
-            }
-          ],
-          "captures": {
-            "1": {
-              "name": "entity.name.function.gleam"
-            }
-          }
+        "begin": "(?:#)?([[:lower:]][[:word:]]*(?:\\.[[:lower:]][[:word:]]*)*)\\(",
+        "end": "\\)",
+        "patterns": [
+          { "include": "$self" }
+        ],
+        "beginCaptures": {
+          "1": { "name": "entity.name.function.gleam" },
+          "0": { "name": "punctuation.parens.begin.gleam" }
+        },
+        "endCaptures": {
+          "0": { "name": "punctuation.parens.end.gleam" }
+        }
         },
         {
           "name": "variable.parameter.gleam",

--- a/syntaxes/gleam.tmLanguage.json
+++ b/syntaxes/gleam.tmLanguage.json
@@ -22,6 +22,9 @@
     },
     {
       "include": "#punctuation"
+    },
+    {
+      "include": "#attributes"
     }
   ],
   "repository": {
@@ -137,6 +140,18 @@
         {
           "name": "comment.line.gleam",
           "match": "\/\/.*"
+        }
+      ]
+    },
+    "attributes": {
+      "patterns": [
+        {
+          "name": "attributes.deprecated.gleam",
+          "match": "@[[:space:]]*deprecated"
+        },
+        {
+          "name": "attributes.external.gleam",
+          "match": "@[[:space:]]*external"
         }
       ]
     },


### PR DESCRIPTION
Add basic pattern for capturing: `{ }`, `[ ]`, ` , `, ` .` ( so that the user can highlight them as they wish)

Before:
<img width="574" height="676" alt="image" src="https://github.com/user-attachments/assets/47baaacd-c56a-4be8-90b3-94c1e847c54c" />


After:
<img width="567" height="661" alt="image" src="https://github.com/user-attachments/assets/67846434-08cf-4b08-a0e3-b98d50b5cd22" />
