### PR TITLE
Allow `gleam.path` to be configured per-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- The `gleam.path` setting can now be configured per-workspace (in
+  `.vscode/settings.json`), in addition to user/machine settings. Useful for
+  projects that use per-project environments such as Mise or Pixi.
+
 ## v2.13.0 - 2026-06-18
 
 - `<<` and `>>` are now auto-closed and can be used to surround selections.

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
         "gleam.path": {
           "type": "string",
           "default": null,
-          "description": "A path to the gleam executable. By default, the extension looks for gleam in the PATH, but if set, will use the path specified instead.",
-          "scope": "machine"
+          "description": "A path to the gleam executable. By default, the extension looks for gleam in the PATH, but if set, will use the path specified instead. Relative paths are resolved against the workspace folder.",
+          "scope": "machine-overridable"
         }
       }
     }


### PR DESCRIPTION
Closes #105 

Adds an option to specify path the Gleam using workspace settings (previously it was only possible to do using user settings). This may be useful for projects that install Gleam as a dependency into project-local environment using tools like Mise or Pixi.  

The only change is setting `{ "gleam.path": { "scope": "machine-overridable" } }` (instead of `"machine"`) in `package.json`, existing implementation already seemed to support this use-case.